### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     name: pre-commit
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/raider444/psytican-bot/security/code-scanning/1](https://github.com/raider444/psytican-bot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `pre-commit` job. Since the job only needs to read the repository contents to run pre-commit hooks, we will set `contents: read` as the permission. This ensures the job has the minimal access required to perform its tasks.

The changes will be made in the `.github/workflows/ci.yaml` file, specifically within the `pre-commit` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
